### PR TITLE
Fix for issue: Weird results with nnSent (#10)

### DIFF
--- a/src/fasttext.cc
+++ b/src/fasttext.cc
@@ -521,7 +521,7 @@ void FastText::findNNSent(const Matrix& sentenceVectors, const Vector& queryVec,
   if (std::abs(queryNorm) < 1e-8) {
     queryNorm = 1;
   }
-  std::priority_queue<std::pair<real, std::string>> heap;
+  std::priority_queue<std::pair<real, std::string>, std::vector<std::pair<real, std::string>>, CompareByFirst > heap;
   Vector vec(args_->dim);
 
   for (int32_t i = 0; i < numSent; i++) {

--- a/src/fasttext.h
+++ b/src/fasttext.h
@@ -29,6 +29,12 @@
 #include "vector.h"
 
 namespace fasttext {
+  
+struct CompareByFirst {
+  constexpr bool operator()(std::pair<real, std::string> const & a,
+                            std::pair<real, std::string> const & b) const noexcept
+  { return a.first < b.first; }
+};
 
 class FastText {
   private:


### PR DESCRIPTION
By default the compare operator for the priority queue with pairs first compares the first elements of the pair. If those elements are the same, the second elements of the pair are compared. 
In your implementation this doesn't make sense, because when predicting nearest neighbor sentences for a query out of the corpora you would like to only rely on the similarity score and not on the real sentences. 
It's very often the case that the similarity score is the same for the dot product between query and corpora sentences. But that's ok. Only all of them need to be returned.

Thus, I suggest to use a custom comparator which only compares the first elements of the pair, i.e. the similarity scores.