### PR TITLE
Cython wrapper to keep model in memory and infer embeddings

### DIFF
--- a/src/fasttext.cc
+++ b/src/fasttext.cc
@@ -432,6 +432,24 @@ void FastText::textVectors() {
   }
 }
 
+void FastText::textVector(std::string text, std::vector<real>& emb) {
+  std::vector<int32_t> line, labels;
+  Vector vec(args_->dim);
+  std::istringstream text_stream(text);
+  dict_->getLine(text_stream, line, labels, model_->rng);
+  vec.zero();
+  if (args_->model == model_name::sent2vec){
+    dict_->addNgrams(line, args_->wordNgrams);
+  }
+  for (auto it = line.cbegin(); it != line.cend(); ++it) {
+    vec.addRow(*input_, *it);
+  }
+  if (!line.empty()) {
+    vec.mul(1.0 / line.size());
+  }
+  emb.insert(emb.end(), &vec.data_[0], &vec.data_[args_->dim]);
+}
+
 void FastText::printWordVectors() {
   wordVectors();
 }

--- a/src/fasttext.h
+++ b/src/fasttext.h
@@ -75,6 +75,7 @@ class FastText {
     void sentenceVectors();
     void ngramVectors(std::string);
     void textVectors();
+    void textVector(std::string, std::vector<real>&);
     void printWordVectors();
     void printSentenceVectors();
     void trainThread(int32_t);

--- a/src/sent2vec.pyx
+++ b/src/sent2vec.pyx
@@ -1,0 +1,42 @@
+import numpy as np
+cimport numpy as np
+
+from libcpp.string cimport string
+from libcpp.vector cimport vector
+
+#np.import_array()
+
+cdef extern from "fasttext.h" namespace "fasttext":
+
+    cdef cppclass FastText:
+        FastText() except + 
+        void loadModel(const string&)
+        void textVector(string, vector[float]&)
+        int getDimension()
+
+
+cdef class Sent2vecModel:
+
+    cdef FastText* _thisptr
+
+    def __cinit__(self):
+        self._thisptr = new FastText()
+
+    def __dealloc__(self):
+        del self._thisptr
+
+    def __init__(self):
+        pass  
+
+    def get_emb_size(self):
+        return self._thisptr.getDimension()
+            
+    def load_model(self, model_path):
+        cdef string cmodel_path = model_path.encode('ascii', 'ignore');
+        self._thisptr.loadModel(cmodel_path)
+
+    def embed_sentence(self, sentence):
+        cdef string csentence = sentence.encode('ascii', 'ignore');
+        cdef vector[float] array;
+        self._thisptr.textVector(csentence, array)
+        return np.asarray(array)

--- a/src/setup.py
+++ b/src/setup.py
@@ -1,0 +1,29 @@
+from distutils.core import setup
+from Cython.Build import cythonize
+from distutils.extension import Extension
+import numpy
+
+sourcefiles  = ['sent2vec.pyx', 
+                'fasttext.cc', 
+                "args.cc", 
+                "dictionary.cc", 
+                "matrix.cc", 
+                "qmatrix.cc", 
+                "model.cc", 
+                'real.cc', 
+                'utils.cc', 
+                'vector.cc', 
+                'real.cc', 
+                'productquantizer.cc']
+compile_opts = ['-std=c++0x', '-Wno-cpp', '-pthread', '-Wno-sign-compare']
+ext=[Extension('*',
+            sourcefiles,
+            extra_compile_args=compile_opts,
+            language='c++',
+            include_dirs=[numpy.get_include()])]
+
+setup(
+  ext_modules=cythonize(ext)
+)
+
+


### PR DESCRIPTION
This PR adds the ability to keep a model in memory and get sentence embeddings directly from python. Previously to get embeddings we had to call the c++ executable which would: 

* load the model
* read sentences from disk
* infer embeddings and write them to disk

After those steps we had to load the inferred embeddings from disk to use them in some program. This process is generating too many I/Os and forces us to reload the model whenever we want new embeddings. 

To solve this problem, I wrote a Cython wrapper exposing the necessary functionalities to load models and infer embeddings:

```python
import sent2vec
model = sent2vec.Sent2vecModel()
model.load_model('model.bin')
emb = model.embed_sentence("once upon a time .")
```

The tokenization is not handled so anyone using this should handle the preprocessing himself. 

To compile the module simply run `python setup.py build_ext --inplace` from the `src` folder.