### PR TITLE
Fixes #36, embed_sentence now uses embed_sentences

### DIFF
--- a/src/fasttext.cc
+++ b/src/fasttext.cc
@@ -472,24 +472,6 @@ void FastText::textVector(std::string text, Vector& vec, std::vector<int32_t>& l
   }
 }
 
-void FastText::textVector(std::string text, std::vector<real>& emb) {
-  std::vector<int32_t> line, labels;
-  Vector vec(args_->dim);
-  std::istringstream text_stream(text);
-  dict_->getLine(text_stream, line, labels, model_->rng);
-  vec.zero();
-  if (args_->model == model_name::sent2vec){
-    dict_->addNgrams(line, args_->wordNgrams);
-  }
-  for (auto it = line.cbegin(); it != line.cend(); ++it) {
-    vec.addRow(*input_, *it);
-  }
-  if (!line.empty()) {
-    vec.mul(1.0 / line.size());
-  }
-  emb.insert(emb.end(), &vec.data_[0], &vec.data_[args_->dim]);
-}
-
 void FastText::printWordVectors() {
   wordVectors();
 }

--- a/src/fasttext.h
+++ b/src/fasttext.h
@@ -75,7 +75,6 @@ class FastText {
     void sentenceVectors();
     void ngramVectors(std::string);
     void textVectors();
-    void textVector(std::string, std::vector<real>&);
     void textVectorThread(int, std::shared_ptr<std::vector<std::string>>, std::shared_ptr<Matrix>, int);
     void textVectors(std::vector<std::string>&, int, std::vector<real>&);
     void textVector(std::string, Vector&, std::vector<int32_t>&, std::vector<int32_t>&);

--- a/src/sent2vec.pyx
+++ b/src/sent2vec.pyx
@@ -81,12 +81,6 @@ cdef class Sent2vecModel:
         cdef string cmodel_path = model_path.encode('utf-8', 'ignore');
         self._thisptr.loadModel(cmodel_path)
 
-    def embed_sentence(self, sentence):
-        cdef string csentence = sentence.encode('utf-8', 'ignore');
-        cdef vector[float] array;
-        self._thisptr.textVector(csentence, array)
-        return np.asarray(array)
-
     def embed_sentences(self, sentences, num_threads=1):
         if num_threads <= 0:
             num_threads = 1
@@ -99,3 +93,6 @@ cdef class Sent2vecModel:
         self._thisptr.textVectors(csentences, cnum_threads, w.buf[0])
         final = w.asarray(len(sentences) * self.get_emb_size()) 
         return final.reshape(len(sentences), self.get_emb_size())
+
+    def embed_sentence(self, sentence, num_threads=1):
+        return self.embed_sentences([sentence], num_threads)


### PR DESCRIPTION
This PR changes the `embed_sentence` that was "kind-of deprecated and very inefficient" and now it calls the `embed_sentences` with the `sentence` as single element list.

```
def embed_sentence(self, sentence, num_threads=1):
    return self.embed_sentences([sentence], num_threads)
```