### PR TITLE
Shared-memory matrix

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@
 
 CXX = c++
 CXXFLAGS = -pthread -std=c++0x
-OBJS = args.o dictionary.o productquantizer.o matrix.o qmatrix.o  vector.o model.o utils.o fasttext.o
+OBJS = args.o dictionary.o productquantizer.o matrix.o shmem_matrix.o qmatrix.o vector.o model.o utils.o fasttext.o
 INCLUDES = -I.
 
 opt: CXXFLAGS += -O3 -funroll-loops
@@ -30,6 +30,9 @@ productquantizer.o: src/productquantizer.cc src/productquantizer.h src/utils.h
 matrix.o: src/matrix.cc src/matrix.h src/utils.h
 	$(CXX) $(CXXFLAGS) -c src/matrix.cc
 
+shmem_matrix.o: src/shmem_matrix.cc src/shmem_matrix.h
+	$(CXX) $(CXXFLAGS) -c src/shmem_matrix.cc
+
 qmatrix.o: src/qmatrix.cc src/qmatrix.h src/utils.h
 	$(CXX) $(CXXFLAGS) -c src/qmatrix.cc
 
@@ -46,7 +49,7 @@ fasttext.o: src/fasttext.cc src/*.h
 	$(CXX) $(CXXFLAGS) -c src/fasttext.cc
 
 fasttext: $(OBJS) src/fasttext.cc
-	$(CXX) $(CXXFLAGS) $(OBJS) src/main.cc -o fasttext
+	$(CXX) $(CXXFLAGS) $(OBJS) src/main.cc -o fasttext -lrt
 
 clean:
 	rm -rf *.o fasttext

--- a/README.md
+++ b/README.md
@@ -52,6 +52,11 @@ There is an 'inference' mode for loading the model in the Cython module, which l
 model.load_model('model.bin', inference_mode=True)
 ```
 
+The model is loaded into a shared memory segment named after the model name. The model will stay in memory until you explicitely remove the shared memory segment. To do it from Python:
+```python
+model.release_shared_mem('model.bin')
+```
+
 # Using Sentence level nearest neighbour search and analogies
 Given a pre-trained model `model.bin` , here is how to use these features. For the nearest neighbouring sentence feature, you need the model as well as a corpora in which you can search for the nearest neighbouring sentence to your input sentence. We use cosine distance as our distance metric. To do so, we use the command `nnSent` and the input should be 1 sentence per line:
 

--- a/README.md
+++ b/README.md
@@ -46,6 +46,13 @@ Text preprocessing (tokenization and lowercasing) is not handled by the module, 
 
 An alternative to the Cython module is using the python code provided in the `get_sentence_embeddings_from_pre-trained_models` notebook. It handles tokenization and can be given raw sentences, but does not keep the model in memory. 
 
+#### Running inference with multiple processes
+
+There is an 'inference' mode for loading the model in the Cython module, which loads the model's input matrix into a shared memory segment and doesn't load the output matrix, which is not needed for inference. This is an optimization for the usecase of running inference with multiple independent processes, which would otherwise each need to load a copy of the model into their address space. To use it:
+```python
+model.load_model('model.bin', inference_mode=True)
+```
+
 # Using Sentence level nearest neighbour search and analogies
 Given a pre-trained model `model.bin` , here is how to use these features. For the nearest neighbouring sentence feature, you need the model as well as a corpora in which you can search for the nearest neighbouring sentence to your input sentence. We use cosine distance as our distance metric. To do so, we use the command `nnSent` and the input should be 1 sentence per line:
 

--- a/README.md
+++ b/README.md
@@ -36,11 +36,10 @@ model.load_model('model.bin')
 emb = model.embed_sentence("once upon a time .") 
 embs = model.embed_sentences(["first sentence .", "another sentence"])  
 ```
-In order to compile and install the module globally, run the following from the `src` folder:
+In order to compile and install the module, run the following from the project root folder:
 
 ```
-python setup.py build_ext
-sudo pip install .
+pip install .
 ```
 Text preprocessing (tokenization and lowercasing) is not handled by the module, check `wikiTokenize.py` for tokenization using NLTK and Stanford NLP. 
 

--- a/setup.py
+++ b/setup.py
@@ -3,19 +3,19 @@ from Cython.Build import cythonize
 from distutils.extension import Extension
 import numpy
 
-sourcefiles  = ['sent2vec.pyx', 
-                'fasttext.cc', 
-                "args.cc", 
-                "dictionary.cc", 
-                "matrix.cc", 
-                "shmem_matrix.cc",
-                "qmatrix.cc", 
-                "model.cc", 
-                'real.cc', 
-                'utils.cc', 
-                'vector.cc', 
-                'real.cc', 
-                'productquantizer.cc']
+sourcefiles  = ['src/sent2vec.pyx',
+                'src/fasttext.cc',
+                'src/args.cc',
+                'src/dictionary.cc',
+                'src/matrix.cc',
+                'src/shmem_matrix.cc',
+                'src/qmatrix.cc',
+                'src/model.cc',
+                'src/real.cc',
+                'src/utils.cc',
+                'src/vector.cc',
+                'src/real.cc',
+                'src/productquantizer.cc']
 compile_opts = ['-std=c++0x', '-Wno-cpp', '-pthread', '-Wno-sign-compare']
 ext=[Extension('*',
             sourcefiles,
@@ -28,5 +28,3 @@ setup(
   name='sent2vec',
   ext_modules=cythonize(ext)
 )
-
-

--- a/src/fasttext.cc
+++ b/src/fasttext.cc
@@ -8,6 +8,7 @@
  */
 
 #include "fasttext.h"
+#include "shmem_matrix.h"
 
 #include <math.h>
 
@@ -124,7 +125,8 @@ void FastText::saveModel() {
   ofs.close();
 }
 
-void FastText::loadModel(const std::string& filename) {
+void FastText::loadModel(const std::string& filename,
+                         const bool predict_mode /* = false */) {
   std::ifstream ifs(filename, std::ifstream::binary);
   if (!ifs.is_open()) {
     std::cerr << "Model file cannot be opened for loading!" << std::endl;
@@ -134,7 +136,11 @@ void FastText::loadModel(const std::string& filename) {
     std::cerr << "Model file has wrong file format!" << std::endl;
     exit(EXIT_FAILURE);
   }
-  loadModel(ifs);
+  if (predict_mode) {
+    loadModelForPredict(ifs);
+  } else {
+    loadModel(ifs);
+  }
   ifs.close();
 }
 
@@ -168,6 +174,32 @@ void FastText::loadModel(std::istream& in) {
   model_ = std::make_shared<Model>(input_, output_, args_, 0);
   model_->quant_ = quant_;
   model_->setQuantizePointer(qinput_, qoutput_, args_->qout);
+
+  if (args_->model == model_name::sup) {
+    model_->setTargetCounts(dict_->getCounts(entry_type::label));
+  } else {
+    model_->setTargetCounts(dict_->getCounts(entry_type::word));
+  }
+}
+
+void FastText::loadModelForPredict(std::istream& in) {
+  args_ = std::make_shared<Args>();
+  args_->load(in);
+
+  dict_ = std::make_shared<Dictionary>(args_);
+  dict_->load(in);
+
+  in.read((char*) &quant_, sizeof(bool));
+
+  input_ = ShmemMatrix::load(in, "s2v_input_matrix");
+
+  in.read((char*) &args_->qout, sizeof(bool));
+
+  output_ = std::make_shared<Matrix>();
+  in.read((char*) &(output_->m_), sizeof(int64_t));
+  in.read((char*) &(output_->n_), sizeof(int64_t));
+
+  model_ = std::make_shared<Model>(input_, output_, args_, 0);
 
   if (args_->model == model_name::sup) {
     model_->setTargetCounts(dict_->getCounts(entry_type::label));

--- a/src/fasttext.cc
+++ b/src/fasttext.cc
@@ -126,7 +126,7 @@ void FastText::saveModel() {
 }
 
 void FastText::loadModel(const std::string& filename,
-                         const bool predict_mode /* = false */) {
+                         const bool inference_mode /* = false */) {
   std::ifstream ifs(filename, std::ifstream::binary);
   if (!ifs.is_open()) {
     std::cerr << "Model file cannot be opened for loading!" << std::endl;
@@ -136,8 +136,8 @@ void FastText::loadModel(const std::string& filename,
     std::cerr << "Model file has wrong file format!" << std::endl;
     exit(EXIT_FAILURE);
   }
-  if (predict_mode) {
-    loadModelForPredict(ifs);
+  if (inference_mode) {
+    loadModelForInference(ifs);
   } else {
     loadModel(ifs);
   }
@@ -182,7 +182,7 @@ void FastText::loadModel(std::istream& in) {
   }
 }
 
-void FastText::loadModelForPredict(std::istream& in) {
+void FastText::loadModelForInference(std::istream& in) {
   args_ = std::make_shared<Args>();
   args_->load(in);
 

--- a/src/fasttext.cc
+++ b/src/fasttext.cc
@@ -137,7 +137,7 @@ void FastText::loadModel(const std::string& filename,
     exit(EXIT_FAILURE);
   }
   if (inference_mode) {
-    loadModelForInference(ifs);
+    loadModelForInference(ifs, filename);
   } else {
     loadModel(ifs);
   }
@@ -182,7 +182,22 @@ void FastText::loadModel(std::istream& in) {
   }
 }
 
-void FastText::loadModelForInference(std::istream& in) {
+static std::string basename(const std::string& filename) {
+  std::string s = filename;
+  size_t separator_idx = s.find_last_of("\\/");
+  if (separator_idx != std::string::npos) {
+    s.erase(0, separator_idx + 1);
+  }
+  size_t extension_idx = s.rfind('.');
+  if (extension_idx != std::string::npos) {
+    s.erase(extension_idx);
+  }
+  return s;
+}
+
+void FastText::loadModelForInference(std::istream& in, const std::string& filename) {
+  std::string shmem_name = "s2v_" + basename(filename) + "_input_matrix";
+
   args_ = std::make_shared<Args>();
   args_->load(in);
 
@@ -191,7 +206,7 @@ void FastText::loadModelForInference(std::istream& in) {
 
   in.read((char*) &quant_, sizeof(bool));
 
-  input_ = ShmemMatrix::load(in, "s2v_input_matrix");
+  input_ = ShmemMatrix::load(in, shmem_name.c_str());
 
   in.read((char*) &args_->qout, sizeof(bool));
 

--- a/src/fasttext.h
+++ b/src/fasttext.h
@@ -57,9 +57,9 @@ class FastText {
     void saveVectors();
     void saveOutput();
     void saveModel();
-    void loadModel(const std::string&, const bool predict_mode = false);
+    void loadModel(const std::string&, const bool inference_mode = false);
     void loadModel(std::istream&);
-    void loadModelForPredict(std::istream&);
+    void loadModelForInference(std::istream&);
     void printInfo(real, real);
 
     void supervised(Model&, real, const std::vector<int32_t>&,

--- a/src/fasttext.h
+++ b/src/fasttext.h
@@ -57,8 +57,9 @@ class FastText {
     void saveVectors();
     void saveOutput();
     void saveModel();
-    void loadModel(const std::string&);
+    void loadModel(const std::string&, const bool predict_mode = false);
     void loadModel(std::istream&);
+    void loadModelForPredict(std::istream&);
     void printInfo(real, real);
 
     void supervised(Model&, real, const std::vector<int32_t>&,

--- a/src/fasttext.h
+++ b/src/fasttext.h
@@ -59,7 +59,7 @@ class FastText {
     void saveModel();
     void loadModel(const std::string&, const bool inference_mode = false);
     void loadModel(std::istream&);
-    void loadModelForInference(std::istream&);
+    void loadModelForInference(std::istream&, const std::string&);
     void printInfo(real, real);
 
     void supervised(Model&, real, const std::vector<int32_t>&,

--- a/src/sent2vec.pyx
+++ b/src/sent2vec.pyx
@@ -1,3 +1,4 @@
+import subprocess
 import numpy as np
 cimport numpy as cnp 
 
@@ -98,3 +99,7 @@ cdef class Sent2vecModel:
 
     def embed_sentence(self, sentence, num_threads=1):
         return self.embed_sentences([sentence], num_threads)
+
+    @staticmethod
+    def release_shared_mem():
+        subprocess.run('unlink /dev/shm/s2v_input_matrix', shell=True)

--- a/src/sent2vec.pyx
+++ b/src/sent2vec.pyx
@@ -1,4 +1,5 @@
 import subprocess
+
 import numpy as np
 cimport numpy as cnp 
 
@@ -79,10 +80,10 @@ cdef class Sent2vecModel:
     def get_emb_size(self):
         return self._thisptr.getDimension()
             
-    def load_model(self, model_path, predict_mode=False):
+    def load_model(self, model_path, inference_mode=False):
         cdef string cmodel_path = model_path.encode('utf-8', 'ignore');
-        cdef bool cpredict_mode = predict_mode
-        self._thisptr.loadModel(cmodel_path, cpredict_mode)
+        cdef bool cinference_mode = inference_mode
+        self._thisptr.loadModel(cmodel_path, cinference_mode)
 
     def embed_sentences(self, sentences, num_threads=1):
         if num_threads <= 0:

--- a/src/sent2vec.pyx
+++ b/src/sent2vec.pyx
@@ -1,3 +1,4 @@
+import os.path
 import subprocess
 
 import numpy as np
@@ -75,7 +76,7 @@ cdef class Sent2vecModel:
         del self._thisptr
 
     def __init__(self):
-        pass  
+        pass
 
     def get_emb_size(self):
         return self._thisptr.getDimension()
@@ -102,5 +103,7 @@ cdef class Sent2vecModel:
         return self.embed_sentences([sentence], num_threads)
 
     @staticmethod
-    def release_shared_mem():
-        subprocess.run('unlink /dev/shm/s2v_input_matrix', shell=True)
+    def release_shared_mem(model_path):
+        model_basename = os.path.splitext(os.path.basename(model_path))[0]
+        shm_path = ''.join(['/dev/shm/', 's2v_', model_basename, '_input_matrix'])
+        subprocess.run(f'unlink {shm_path}', shell=True)

--- a/src/sent2vec.pyx
+++ b/src/sent2vec.pyx
@@ -1,6 +1,7 @@
 import numpy as np
 cimport numpy as cnp 
 
+from libcpp cimport bool
 from libcpp.string cimport string
 from libcpp.vector cimport vector
 
@@ -13,7 +14,7 @@ cdef extern from "fasttext.h" namespace "fasttext":
 
     cdef cppclass FastText:
         FastText() except + 
-        void loadModel(const string&)
+        void loadModel(const string&, bool)
         void textVector(string, vector[float]&)
         void textVectors(vector[string]&, int, vector[float])#&)
         int getDimension()
@@ -31,7 +32,7 @@ cdef class vector_wrapper:
     cdef: 
         vector[float] *buf 
 
-    def __cinit__(vector_wrapper self, n): 
+    def __cinit__(vector_wrapper self, n):
         self.buf = NULL 
 
     def __init__(vector_wrapper self, cnp.intp_t n): 
@@ -77,9 +78,10 @@ cdef class Sent2vecModel:
     def get_emb_size(self):
         return self._thisptr.getDimension()
             
-    def load_model(self, model_path):
+    def load_model(self, model_path, predict_mode=False):
         cdef string cmodel_path = model_path.encode('utf-8', 'ignore');
-        self._thisptr.loadModel(cmodel_path)
+        cdef bool cpredict_mode = predict_mode
+        self._thisptr.loadModel(cmodel_path, cpredict_mode)
 
     def embed_sentences(self, sentences, num_threads=1):
         if num_threads <= 0:

--- a/src/setup.py
+++ b/src/setup.py
@@ -8,6 +8,7 @@ sourcefiles  = ['sent2vec.pyx',
                 "args.cc", 
                 "dictionary.cc", 
                 "matrix.cc", 
+                "shmem_matrix.cc",
                 "qmatrix.cc", 
                 "model.cc", 
                 'real.cc', 
@@ -20,7 +21,8 @@ ext=[Extension('*',
             sourcefiles,
             extra_compile_args=compile_opts,
             language='c++',
-            include_dirs=[numpy.get_include()])]
+            include_dirs=[numpy.get_include()],
+            libraries=['rt'])]
 
 setup(
   name='sent2vec',

--- a/src/shmem_matrix.cc
+++ b/src/shmem_matrix.cc
@@ -1,0 +1,126 @@
+/**
+ * Copyright (c) 2016-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+#include <errno.h>
+#include <fcntl.h>
+#include <memory>
+#include <stdio.h>
+#include <stdlib.h>
+#include <sys/mman.h>
+#include <unistd.h>
+
+#include "shmem_matrix.h"
+
+namespace fasttext {
+
+ShmemMatrix::ShmemMatrix(const char* name, const int64_t m, const int64_t n) {
+  m_ = m;
+  n_ = n;
+
+  // Open an existing shared memory segment
+  int fd = shm_open(name, O_RDONLY, 0644);
+  if (fd == -1) {
+    perror("ShmemMatrix::ShmemMatrix: shm_open failed");
+    exit(-1);
+  }
+
+  // Map the shared memory segment
+  size_t size = m_ * n_ * sizeof(real);
+  void* ptr = mmap(NULL, size, PROT_READ, MAP_SHARED, fd, 0);
+  if (ptr == (void*)-1) {
+    perror("ShmemMatrix::ShmemMatrix: mmap failed");
+    exit(-1);
+  } else {
+    data_ = (real*)ptr;
+  }
+
+  // Close the file descriptor
+  int ret = close(fd);
+  if (ret == -1) {
+    perror("ShmemMatrix::ShmemMatrix: close failed");
+    exit(-1);
+  }
+}
+
+ShmemMatrix::~ShmemMatrix() {
+  // Unmap the shared memory segment
+  size_t size = m_ * n_ * sizeof(real);
+  int ret = munmap((void*)data_, size);
+  if (ret == -1) {
+    perror("ShmemMatrix::~ShmemMatrix: munmap failed");
+    exit(-1);
+  }
+  data_ = nullptr;
+}
+
+std::shared_ptr<ShmemMatrix> ShmemMatrix::load(std::istream& in, const char* name) {
+  int64_t m, n;
+  in.read((char*)&m, sizeof(int64_t));
+  in.read((char*)&n, sizeof(int64_t));
+  size_t size = m * n * sizeof(real);
+
+  // Create a shared memory segment
+  bool new_segment = true;
+  int fd = shm_open(name, O_RDWR | O_CREAT | O_EXCL, 0644);
+  if (fd == -1) {
+    if (errno == EEXIST) {
+      new_segment = false;
+    } else {
+      perror("ShmemMatrix::load: shm_open failed");
+      exit(-1);
+    }
+  }
+
+  if (new_segment) {
+    // Set the size for shared memory segment
+    int ret = ftruncate(fd, size);
+    if (ret == -1) {
+      perror("ShmemMatrix::load: ftruncate failed");
+      exit(-1);
+    }
+
+    // Map the shared memory segment
+    void* ptr = mmap(NULL, size, PROT_WRITE, MAP_SHARED, fd, 0);
+    if (ptr == (void*)-1) {
+      perror("ShmemMatrix::load: mmap failed");
+      exit(-1);
+    }
+
+    // Populate the shared memory segment
+    in.read((char*)ptr, size);
+
+    // Unmap the shared memory segment
+    ret = munmap(ptr, size);
+    if (ret == -1) {
+      perror("ShmemMatrix::load: munmap failed");
+      exit(-1);
+    }
+  } else {
+    // Seek in the stream to skip the input matrix data
+    in.seekg(size, in.cur);
+  }
+
+  auto matrix = std::make_shared<ShmemMatrix>(name, m, n);
+
+  //TODO: Unlink is only safe to do once every process has opened the shared
+  //      memory segment. This is hard to do from the code. One way would be
+  //      to put a refcount in the segment itself, which would also require
+  //      the segment to be opened as O_RDWR, and the refcount should be
+  //      protected by an IPC semaphore.
+  //// Unlink the shared memory segment
+  //int ret = shm_unlink(name);
+  //if (ret == -1) {
+  //  perror("shm_unlink failed");
+  //  exit(-1);
+  //}
+
+  return matrix;
+}
+
+}

--- a/src/shmem_matrix.cc
+++ b/src/shmem_matrix.cc
@@ -24,7 +24,7 @@ ShmemMatrix::ShmemMatrix(const char* name, const int64_t m, const int64_t n) {
   n_ = n;
 
   // Open an existing shared memory segment
-  int fd = shm_open(name, O_RDONLY, 0644);
+  int fd = shm_open(name, O_RDONLY, 0444);
   if (fd == -1) {
     perror("ShmemMatrix::ShmemMatrix: shm_open failed");
     exit(-1);
@@ -67,7 +67,7 @@ std::shared_ptr<ShmemMatrix> ShmemMatrix::load(std::istream& in, const char* nam
 
   // Create a shared memory segment
   bool new_segment = true;
-  int fd = shm_open(name, O_RDWR | O_CREAT | O_EXCL, 0644);
+  int fd = shm_open(name, O_RDWR | O_CREAT | O_EXCL, 0444);
   if (fd == -1) {
     if (errno == EEXIST) {
       new_segment = false;

--- a/src/shmem_matrix.h
+++ b/src/shmem_matrix.h
@@ -1,0 +1,37 @@
+/**
+ * Copyright (c) 2016-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+#ifndef FASTTEXT_SHMEM_MATRIX_H
+#define FASTTEXT_SHMEM_MATRIX_H
+
+#include <cstdint>
+#include <istream>
+#include <memory>
+#include <ostream>
+
+#include "matrix.h"
+#include "real.h"
+
+namespace fasttext {
+
+class ShmemMatrix : public Matrix {
+  public:
+    ShmemMatrix(const char*, const int64_t, const int64_t);
+    ~ShmemMatrix();
+
+    Matrix& operator=(const Matrix&) = delete;
+    void save(std::ostream&) = delete;
+    void load(std::istream&) = delete;
+
+    static std::shared_ptr<ShmemMatrix> load(std::istream&, const char*);
+};
+
+}
+
+#endif


### PR DESCRIPTION
It's about optimizing memory usage when doing inference with multiple processes. Instead of each process loading the matrix, it is only loaded once in a shared memory region and used by all processes. This can also speed up the startup time if matrix is preloaded. The output matrix is not loaded at all as it is not needed during inference, which saves just under 50% of memory. There is no loss in speed, and potential savings in RAM can be huge.