### PR TITLE
Fix: Safeguard access to shared memory during matrix loading

### DIFF
--- a/src/fasttext.cc
+++ b/src/fasttext.cc
@@ -126,7 +126,8 @@ void FastText::saveModel() {
 }
 
 void FastText::loadModel(const std::string& filename,
-                         const bool inference_mode /* = false */) {
+                         const bool inference_mode /* = false */,
+                         const int timeout_sec /* = -1 */) {
   std::ifstream ifs(filename, std::ifstream::binary);
   if (!ifs.is_open()) {
     std::cerr << "Model file cannot be opened for loading!" << std::endl;
@@ -137,7 +138,7 @@ void FastText::loadModel(const std::string& filename,
     exit(EXIT_FAILURE);
   }
   if (inference_mode) {
-    loadModelForInference(ifs, filename);
+    loadModelForInference(ifs, filename, timeout_sec);
   } else {
     loadModel(ifs);
   }
@@ -195,7 +196,9 @@ static std::string basename(const std::string& filename) {
   return s;
 }
 
-void FastText::loadModelForInference(std::istream& in, const std::string& filename) {
+void FastText::loadModelForInference(std::istream& in,
+                                     const std::string& filename,
+                                     const int timeout_sec) {
   std::string shmem_name = "s2v_" + basename(filename) + "_input_matrix";
 
   args_ = std::make_shared<Args>();
@@ -206,7 +209,7 @@ void FastText::loadModelForInference(std::istream& in, const std::string& filena
 
   in.read((char*) &quant_, sizeof(bool));
 
-  input_ = ShmemMatrix::load(in, shmem_name.c_str());
+  input_ = ShmemMatrix::load(in, shmem_name, timeout_sec);
 
   in.read((char*) &args_->qout, sizeof(bool));
 

--- a/src/fasttext.h
+++ b/src/fasttext.h
@@ -57,9 +57,9 @@ class FastText {
     void saveVectors();
     void saveOutput();
     void saveModel();
-    void loadModel(const std::string&, const bool inference_mode = false);
+    void loadModel(const std::string&, const bool inference_mode = false, const int timeout_sec = -1);
     void loadModel(std::istream&);
-    void loadModelForInference(std::istream&, const std::string&);
+    void loadModelForInference(std::istream&, const std::string&, const int);
     void printInfo(real, real);
 
     void supervised(Model&, real, const std::vector<int32_t>&,

--- a/src/sent2vec.pyx
+++ b/src/sent2vec.pyx
@@ -17,7 +17,7 @@ cdef extern from "fasttext.h" namespace "fasttext":
 
     cdef cppclass FastText:
         FastText() except + 
-        void loadModel(const string&, bool)
+        void loadModel(const string&, bool, int)
         void textVector(string, vector[float]&)
         void textVectors(vector[string]&, int, vector[float])#&)
         int getDimension()
@@ -81,10 +81,11 @@ cdef class Sent2vecModel:
     def get_emb_size(self):
         return self._thisptr.getDimension()
             
-    def load_model(self, model_path, inference_mode=False):
+    def load_model(self, model_path, inference_mode=False, timeout_sec=-1):
         cdef string cmodel_path = model_path.encode('utf-8', 'ignore');
         cdef bool cinference_mode = inference_mode
-        self._thisptr.loadModel(cmodel_path, cinference_mode)
+        cdef int ctimeout_sec = timeout_sec
+        self._thisptr.loadModel(cmodel_path, cinference_mode, ctimeout_sec)
 
     def embed_sentences(self, sentences, num_threads=1):
         if num_threads <= 0:
@@ -106,4 +107,5 @@ cdef class Sent2vecModel:
     def release_shared_mem(model_path):
         model_basename = os.path.splitext(os.path.basename(model_path))[0]
         shm_path = ''.join(['/dev/shm/', 's2v_', model_basename, '_input_matrix'])
+        subprocess.run(f'unlink {shm_path}.init', shell=True)
         subprocess.run(f'unlink {shm_path}', shell=True)

--- a/src/shmem_matrix.h
+++ b/src/shmem_matrix.h
@@ -14,6 +14,7 @@
 #include <istream>
 #include <memory>
 #include <ostream>
+#include <string>
 
 #include "matrix.h"
 #include "real.h"
@@ -22,14 +23,14 @@ namespace fasttext {
 
 class ShmemMatrix : public Matrix {
   public:
-    ShmemMatrix(const char*, const int64_t, const int64_t);
+    ShmemMatrix(const char*, const int64_t, const int64_t, const int);
     ~ShmemMatrix();
 
     Matrix& operator=(const Matrix&) = delete;
     void save(std::ostream&) = delete;
     void load(std::istream&) = delete;
 
-    static std::shared_ptr<ShmemMatrix> load(std::istream&, const char*);
+    static std::shared_ptr<ShmemMatrix> load(std::istream&, const std::string&, const int);
 };
 
 }


### PR DESCRIPTION
Processes started concurrently could access shared memory before the
input matrix was loaded into it. Now, the matrix is loaded into a
different path than the one processes expect and hardlinked with the
proper one once the loading is finished. Processes may have to wait at
startup for this to finish, and an optional timeout parameter is added
to prevent them from waiting forever in case of error.