### PR TITLE
Import standard int64_t instead of ctypedef'ing it

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,9 @@ CXX = c++
 CXXFLAGS = -pthread -std=c++0x
 OBJS = args.o dictionary.o productquantizer.o matrix.o shmem_matrix.o qmatrix.o vector.o model.o utils.o fasttext.o
 INCLUDES = -I.
+ifneq ($(shell uname),Darwin)
+	LINK_RT := -lrt
+endif
 
 opt: CXXFLAGS += -O3 -funroll-loops
 opt: fasttext
@@ -49,7 +52,7 @@ fasttext.o: src/fasttext.cc src/*.h
 	$(CXX) $(CXXFLAGS) -c src/fasttext.cc
 
 fasttext: $(OBJS) src/fasttext.cc
-	$(CXX) $(CXXFLAGS) $(OBJS) src/main.cc -o fasttext -lrt
+	$(CXX) $(CXXFLAGS) $(OBJS) src/main.cc -o fasttext $(LINK_RT)
 
 clean:
 	rm -rf *.o fasttext

--- a/setup.py
+++ b/setup.py
@@ -1,3 +1,4 @@
+import sys
 from distutils.core import setup
 from Cython.Build import cythonize
 from distutils.extension import Extension
@@ -17,12 +18,15 @@ sourcefiles  = ['src/sent2vec.pyx',
                 'src/real.cc',
                 'src/productquantizer.cc']
 compile_opts = ['-std=c++0x', '-Wno-cpp', '-pthread', '-Wno-sign-compare']
+libraries = ['rt']
+if sys.platform == 'darwin':
+    libraries = []
 ext=[Extension('*',
             sourcefiles,
             extra_compile_args=compile_opts,
             language='c++',
             include_dirs=[numpy.get_include()],
-            libraries=['rt'])]
+            libraries=libraries)]
 
 setup(
   name='sent2vec',

--- a/src/sent2vec.pyx
+++ b/src/sent2vec.pyx
@@ -8,11 +8,10 @@ cimport numpy as cnp
 from libcpp cimport bool
 from libcpp.string cimport string
 from libcpp.vector cimport vector
+from libc.stdint cimport int64_t
 
 #from libc.stdlib cimport free
 #from cpython cimport PyObject, Py_INCREF
-
-ctypedef long int64_t
 
 cnp.import_array()
 


### PR DESCRIPTION
When I tried to compile last version on OS X 10.14 (Python 3.7.0, Cython 0.29.7), I encountered this error:

```
> python setup.py bdist
...
src/sent2vec.cpp:3932:15: error: no matching function for call to '__pyx_convert_vector_to_py___pyx_t_8sent2vec_int64_t'
  __pyx_t_2 = __pyx_convert_vector_to_py___pyx_t_8sent2vec_int64_t(__pyx_v_self->_thisptr->getUnigramsCounts()); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 114, __pyx_L1_error)
              ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
src/sent2vec.cpp:2000:18: note: candidate function not viable: no known conversion from 'vector<int64_t>' to 'const vector<__pyx_t_8sent2vec_int64_t>' for 1st argument
static PyObject *__pyx_convert_vector_to_py___pyx_t_8sent2vec_int64_t(const std::vector<__pyx_t_8sent2vec_int64_t>  &); /*proto*/
                 ^
1 error generated.
error: command 'clang' failed with exit status 1
```

The code where the problem occured looked as simple as it gets, just a simple conversion of `vector<int64_t>` to Python list. However, the c++ function name was somewhat suspicious, and so did the type `__pyx_t_8sent2vec_int64_t`. Why the type of an integer had a `sent2vec` in it? Turns out, because `int64_t` was defined in `sent2vec.pyx`. And somehow compiler on Linux could figure out that it's the same as standard, and on OSX it didn't. 

So I just changed ctypedef to a proper import of a standard type and the file compiled.

Also, to get it to link I had to remove `rt` library in setup.py for python library, and in Makefile for a binary. If you want, I can create a PR that removes that library if the build happens on OSX.