### PR TITLE
Install Cython and NumPy before executing setup.py

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,6 @@
+[build-system]
+requires = [
+    "setuptools",
+    "wheel",
+    "Cython>=0.29.13",
+    "numpy>=1.17.1"]

--- a/setup.py
+++ b/setup.py
@@ -30,5 +30,6 @@ ext=[Extension('*',
 
 setup(
   name='sent2vec',
+  install_requires=['Cython>=0.29.13', 'numpy>=1.17.1'],
   ext_modules=cythonize(ext)
 )


### PR DESCRIPTION
### Problem
Cython and NumPy need to be manually installed before running `setup.py`.

### Consequence
`sent2vec` cannot be included in other packages' dependencies because the installation will break if `cython` or `numpy` are not installed.

### Solution
Include a `pyproject.toml` file, which makes sure that Cython and NumPy are installed
before the setup script is executed.

This is the officially recommended way of distributing Cython modules [[1]] and is supported by pip starting version 10.0. [[2]]

### Note
If `Cython` and `NumPy` are not required after the install then the `install_requires` line in `setup.py` can be removed.

[1]: https://cython.readthedocs.io/en/latest/src/userguide/source_files_and_compilation.html#distributing-cython-modules
[2]: https://pip.pypa.io/en/stable/reference/pip/#pep-517-and-518-support