### PR TITLE
mac-os patch for fasttext shared memory problem

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,6 @@
 *.exe
 *.out
 *.app
+
+# Strange file
+fasttext

--- a/src/fasttext.h
+++ b/src/fasttext.h
@@ -61,9 +61,10 @@ class FastText {
     void saveModel(int32_t);
     void saveDict();
 
-    void loadModel(const std::string&, const bool inference_mode = false, const int timeout_sec = -1);
-    void loadModel(std::istream&);
-    void loadModelForInference(std::istream&, const std::string&, const int);
+    void loadModel(const std::string&, const bool inference_mode = false, const bool shared_mem_enabled = true,
+                   const int timeout_sec = -1);
+    void loadModel(std::istream&, bool load_output_matrix = true);
+    void loadModelWithSharedMemory(std::istream&, const std::string&, const int);
     void loadDict(const std::string&);
     void loadDict(std::istream&);
     void printInfo(real, real);

--- a/src/sent2vec.pyx
+++ b/src/sent2vec.pyx
@@ -1,3 +1,4 @@
+import sys
 import os.path
 import subprocess
 from collections import OrderedDict
@@ -19,7 +20,7 @@ cdef extern from "fasttext.h" namespace "fasttext":
 
     cdef cppclass FastText:
         FastText() except +
-        void loadModel(const string&, bool, int)
+        void loadModel(const string&, bool, bool, int)
         void textVector(string, vector[float]&)
         void textVectors(vector[string]&, int, vector[float])#&)
         int getDimension()
@@ -88,8 +89,10 @@ cdef class Sent2vecModel:
     def load_model(self, model_path, inference_mode=False, timeout_sec=-1):
         cdef string cmodel_path = model_path.encode('utf-8', 'ignore');
         cdef bool cinference_mode = inference_mode
+        # Check if system has shared memory enabled. As of now, only Linux seems to have it.
+        cdef bool cshared_memory_enabled = sys.platform.startswith('linux')
         cdef int ctimeout_sec = timeout_sec
-        self._thisptr.loadModel(cmodel_path, cinference_mode, ctimeout_sec)
+        self._thisptr.loadModel(cmodel_path, cinference_mode, cshared_memory_enabled, ctimeout_sec)
 
     def embed_sentences(self, sentences, num_threads=1):
         if num_threads <= 0:


### PR DESCRIPTION
Hi Matteo,
this is the implementation of the fasttext improvement that makes sent2vec runable on macOS.
Regards,
Jo